### PR TITLE
Add metadata and inspect debug info

### DIFF
--- a/ast_tools/passes/base.py
+++ b/ast_tools/passes/base.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta, abstractmethod
-from collections import MutableMapping
 import ast
 import typing as tp
 
@@ -7,7 +6,7 @@ from ast_tools.stack import SymbolTable
 
 __ALL__ = ['Pass', 'PASS_ARGS_T']
 
-PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable, MutableMapping]
+PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable, tp.MutableMapping]
 
 class Pass(metaclass=ABCMeta):
     """
@@ -22,7 +21,7 @@ class Pass(metaclass=ABCMeta):
     def rewrite(self,
             env: SymbolTable,
             tree: ast.AST,
-            metadata: MutableMapping,
+            metadata: tp.MutableMapping,
             ) -> PASS_ARGS_T:
 
         """

--- a/ast_tools/passes/base.py
+++ b/ast_tools/passes/base.py
@@ -6,7 +6,7 @@ from ast_tools.stack import SymbolTable
 
 __ALL__ = ['Pass', 'PASS_ARGS_T']
 
-PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable]
+PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable, dict]
 
 class Pass(metaclass=ABCMeta):
     """

--- a/ast_tools/passes/base.py
+++ b/ast_tools/passes/base.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from collections import MutableMapping
 import ast
 import typing as tp
 
@@ -6,7 +7,7 @@ from ast_tools.stack import SymbolTable
 
 __ALL__ = ['Pass', 'PASS_ARGS_T']
 
-PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable, dict]
+PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable, MutableMapping]
 
 class Pass(metaclass=ABCMeta):
     """
@@ -21,7 +22,7 @@ class Pass(metaclass=ABCMeta):
     def rewrite(self,
             env: SymbolTable,
             tree: ast.AST,
-            metadata: dict,
+            metadata: MutableMapping,
             ) -> PASS_ARGS_T:
 
         """

--- a/ast_tools/passes/base.py
+++ b/ast_tools/passes/base.py
@@ -21,6 +21,7 @@ class Pass(metaclass=ABCMeta):
     def rewrite(self,
             env: SymbolTable,
             tree: ast.AST,
+            metadata: dict,
             ) -> PASS_ARGS_T:
 
         """

--- a/ast_tools/passes/debug.py
+++ b/ast_tools/passes/debug.py
@@ -1,7 +1,6 @@
 import ast
 import typing as tp
 import warnings
-from collections import MutableMapping
 
 import astor
 
@@ -34,7 +33,7 @@ class debug(Pass):
     def rewrite(self,
             tree: ast.AST,
             env: SymbolTable,
-            metadata: MutableMapping,
+            metadata: tp.MutableMapping,
             ) -> PASS_ARGS_T:
 
         def _do_dumps(dumps, dump_writer):

--- a/ast_tools/passes/debug.py
+++ b/ast_tools/passes/debug.py
@@ -1,6 +1,7 @@
 import ast
 import typing as tp
 import warnings
+from collections import MutableMapping
 
 import astor
 
@@ -33,7 +34,7 @@ class debug(Pass):
     def rewrite(self,
             tree: ast.AST,
             env: SymbolTable,
-            metadata: dict,
+            metadata: MutableMapping,
             ) -> PASS_ARGS_T:
 
         def _do_dumps(dumps, dump_writer):

--- a/ast_tools/passes/debug.py
+++ b/ast_tools/passes/debug.py
@@ -74,4 +74,4 @@ class debug(Pass):
             def _print(*args, **kwargs): print(*args, end='', **kwargs)
             _do_dumps(dumps, _print)
 
-        return tree, env
+        return tree, env, metadata

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -342,7 +342,7 @@ class ssa(Pass):
     def __init__(self, return_prefix: str = '__return_value'):
         self.return_prefix = return_prefix
 
-    def rewrite(self, tree: ast.AST, env: SymbolTable):
+    def rewrite(self, tree: ast.AST, env: SymbolTable, metadata: dict):
         if not isinstance(tree, ast.FunctionDef):
             raise TypeError('ssa should only be applied to functions')
         r_name = gen_free_prefix(tree, env, self.return_prefix)
@@ -353,4 +353,4 @@ class ssa(Pass):
                 value=_build_return(visitor.returns)
             )
         )
-        return tree, env
+        return tree, env, metadata

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -1,5 +1,5 @@
 import ast
-from collections import ChainMap, Counter, MutableMapping
+from collections import ChainMap, Counter
 import itertools
 import warnings
 import weakref
@@ -342,7 +342,7 @@ class ssa(Pass):
     def __init__(self, return_prefix: str = '__return_value'):
         self.return_prefix = return_prefix
 
-    def rewrite(self, tree: ast.AST, env: SymbolTable, metadata: MutableMapping):
+    def rewrite(self, tree: ast.AST, env: SymbolTable, metadata: tp.MutableMapping):
         if not isinstance(tree, ast.FunctionDef):
             raise TypeError('ssa should only be applied to functions')
         r_name = gen_free_prefix(tree, env, self.return_prefix)

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -1,5 +1,5 @@
 import ast
-from collections import ChainMap, Counter
+from collections import ChainMap, Counter, MutableMapping
 import itertools
 import warnings
 import weakref
@@ -342,7 +342,7 @@ class ssa(Pass):
     def __init__(self, return_prefix: str = '__return_value'):
         self.return_prefix = return_prefix
 
-    def rewrite(self, tree: ast.AST, env: SymbolTable, metadata: dict):
+    def rewrite(self, tree: ast.AST, env: SymbolTable, metadata: MutableMapping):
         if not isinstance(tree, ast.FunctionDef):
             raise TypeError('ssa should only be applied to functions')
         r_name = gen_free_prefix(tree, env, self.return_prefix)

--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -1,6 +1,7 @@
 import inspect
 import ast
 import typing as tp
+from collections import MutableMapping
 
 from . import Pass
 from . import PASS_ARGS_T
@@ -44,7 +45,7 @@ class end_rewrite(Pass):
     def rewrite(self,
             tree: ast.AST,
             env: SymbolTable,
-            metadata: dict) -> tp.Union[tp.Callable, type]:
+            metadata: MutableMapping) -> tp.Union[tp.Callable, type]:
         decorators = []
         first_group = True
         in_group = False

--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -1,3 +1,4 @@
+import inspect
 import ast
 import typing as tp
 
@@ -13,13 +14,18 @@ class begin_rewrite:
     """
     begins a chain of passes
     """
-    def __init__(self):
+    def __init__(self, debug=False):
         env = get_symbol_table([self.__init__])
         self.env = env
+        self.debug = debug
 
     def __call__(self, fn) -> PASS_ARGS_T:
         tree = get_ast(fn)
-        return tree, self.env
+        metadata = {}
+        if self.debug:
+            metadata["source_filename"] = inspect.getsourcefile(fn)
+            metadata["source_lines"] = inspect.getsourcelines(fn)
+        return tree, self.env, metadata
 
 def _issubclass(t, s) -> bool:
     try:
@@ -37,7 +43,8 @@ class end_rewrite(Pass):
 
     def rewrite(self,
             tree: ast.AST,
-            env: SymbolTable) -> tp.Union[tp.Callable, type]:
+            env: SymbolTable,
+            metadata: dict) -> tp.Union[tp.Callable, type]:
         decorators = []
         first_group = True
         in_group = False

--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -1,7 +1,6 @@
 import inspect
 import ast
 import typing as tp
-from collections import MutableMapping
 
 from . import Pass
 from . import PASS_ARGS_T
@@ -45,7 +44,7 @@ class end_rewrite(Pass):
     def rewrite(self,
             tree: ast.AST,
             env: SymbolTable,
-            metadata: MutableMapping) -> tp.Union[tp.Callable, type]:
+            metadata: tp.MutableMapping) -> tp.Union[tp.Callable, type]:
         decorators = []
         first_group = True
         in_group = False

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -34,9 +34,9 @@ def test_debug(capsys):
     @begin_rewrite(debug=True)
     def foo():
         print("bar")
-    assert capsys.readouterr().out == """\
+    assert capsys.readouterr().out == f"""\
 BEGIN SOURCE_FILENAME
-/Users/leonardtruong/repos/ast_tools/tests/test_passes.py
+{os.path.abspath(__file__)}
 END SOURCE_FILENAME
 
 BEGIN SOURCE_LINES

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -49,3 +49,24 @@ BEGIN SOURCE_LINES
 END SOURCE_LINES
 
 """
+
+
+def test_debug_error():
+
+    try:
+        @end_rewrite
+        @debug(dump_source_filename=True)
+        @begin_rewrite()
+        def foo():
+            print("bar")
+    except Exception as e:
+        assert str(e) == "Cannot dump source filename without @begin_rewrite(debug=True)"
+
+    try:
+        @end_rewrite
+        @debug(dump_source_lines=True)
+        @begin_rewrite()
+        def foo():
+            print("bar")
+    except Exception as e:
+        assert str(e) == "Cannot dump source lines without @begin_rewrite(debug=True)"

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 
-from ast_tools.passes import begin_rewrite, end_rewrite
+from ast_tools.passes import begin_rewrite, end_rewrite, debug
 
 
 
@@ -25,3 +25,26 @@ def test_begin_end():
 def foo():
     pass
 '''
+
+
+def test_debug(capsys):
+
+    @end_rewrite
+    @debug(dump_source_filename=True, dump_source_lines=True)
+    @begin_rewrite(debug=True)
+    def foo():
+        print("bar")
+    assert capsys.readouterr().out == """\
+BEGIN SOURCE_FILENAME
+/Users/leonardtruong/repos/ast_tools/tests/test_passes.py
+END SOURCE_FILENAME
+
+BEGIN SOURCE_LINES
+32:    @end_rewrite
+33:    @debug(dump_source_filename=True, dump_source_lines=True)
+34:    @begin_rewrite(debug=True)
+35:    def foo():
+36:        print("bar")
+END SOURCE_LINES
+
+"""

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,3 +1,4 @@
+import os
 import functools
 import inspect
 
@@ -40,11 +41,11 @@ BEGIN SOURCE_FILENAME
 END SOURCE_FILENAME
 
 BEGIN SOURCE_LINES
-32:    @end_rewrite
-33:    @debug(dump_source_filename=True, dump_source_lines=True)
-34:    @begin_rewrite(debug=True)
-35:    def foo():
-36:        print("bar")
+33:    @end_rewrite
+34:    @debug(dump_source_filename=True, dump_source_lines=True)
+35:    @begin_rewrite(debug=True)
+36:    def foo():
+37:        print("bar")
 END SOURCE_LINES
 
 """


### PR DESCRIPTION
This adds logic to pass a metadata dictionary between passes. The initial entries are `source_filename` and `source_lines` which are populated by `inspect.getsourcefile(fn)` and `inspect.getsourcelines(fn)` when the flags are set for `begin_rewrite`. This debug information is used by magma to generate error messages (the important part of getsourcelines is that it provides the starting line number and the actual source lines which could be different compared to simply unparsing the AST (e.g. if there are linebreaks in the user code not represented in the AST).