### PR TITLE
Sort keys for phi generation, ignore .ast_tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 dist
 ast_tools.egg-info
+.ast_tools

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -191,7 +191,7 @@ class SSATransformer(ast.NodeTransformer):
                     )
 
             # names in body, names in orelse
-            for name in t_nt.keys() | f_nt.keys():
+            for name in sorted(t_nt.keys() | f_nt.keys()):
                 if name in t_nt and name in f_nt:
                     # mux between true and false
                     suite.append(_mux_name(name, t_nt[name], f_nt[name]))


### PR DESCRIPTION
This ensures that phis are created in sorted order, which is helpful for downstream compiler tests that regress on the output source code.