### PR TITLE
Instrumentation

### DIFF
--- a/ast_tools/importer/__init__.py
+++ b/ast_tools/importer/__init__.py
@@ -1,0 +1,1 @@
+from .importer import *

--- a/ast_tools/importer/importer.py
+++ b/ast_tools/importer/importer.py
@@ -1,0 +1,53 @@
+import importlib
+import importlib.abc
+import importlib.machinery
+import os
+import types
+import sys
+
+from ast_tools.stack import SymbolTable
+from ast_tools.common import exec_tree_in_file
+from ast_tools import immutable_ast as iast
+__ALL__ = ['module_passes', 'RewriteImporter']
+
+module_passes = []
+
+class RewriteImporter(
+        importlib.machinery.PathFinder,
+        importlib.abc.Loader):
+
+    @classmethod
+    def find_spec(cls, fullname, path, target=None):
+        spec = super().find_spec(fullname, path, target)
+        if spec is not None:
+            spec.loader = cls
+        return spec
+
+
+    @classmethod
+    def create_module(cls, spec):
+        module = types.ModuleType(spec.name)
+        module.__spec__ = spec
+        module.__name__ = spec.name
+        module.__loader__ = spec.loader
+        module.__file__ = spec.origin
+        module.__path__ = spec.submodule_search_locations
+        module.__cached__ = spec.cached
+        module.__package__ = spec.parent
+        return module
+
+    @classmethod
+    def exec_module(cls, module):
+        src_file = module.__file__
+        with open(src_file, 'rb') as src:
+            src_code = src.read()
+
+        tree = iast.parse(src_code)
+        env = SymbolTable(module.__dict__, module.__dict__)
+        metadata = {}
+
+        for pass_ in module_passes:
+            tree, env, metadata = pass_.rewrite(tree, env, metadata)
+
+        module.__dict__.update(exec_tree_in_file(tree, env, file_name=os.path.basename(src_file)))
+

--- a/ast_tools/instrumentation.py
+++ b/ast_tools/instrumentation.py
@@ -6,12 +6,12 @@ from ast_tools.passes import InstrumentationPass
 from ast_tools.passes.instrumentation import INFO
 
 _active = False
-def activate():
+def activate(store_env: bool = True):
     global _active
     if not _active:
         _active = True
         sys.meta_path.insert(0, RewriteImporter)
-        module_passes.append(InstrumentationPass())
+        module_passes.append(InstrumentationPass(store_env))
 
 def deactivate():
     global _active

--- a/ast_tools/instrumentation.py
+++ b/ast_tools/instrumentation.py
@@ -1,0 +1,31 @@
+import sys
+
+from ast_tools.importer import RewriteImporter
+from ast_tools.importer import module_passes
+from ast_tools.passes import InstrumentationPass
+from ast_tools.passes.instrumentation import INFO
+
+_active = False
+def activate():
+    global _active
+    if not _active:
+        _active = True
+        sys.meta_path.insert(0, RewriteImporter)
+        module_passes.append(InstrumentationPass())
+
+def deactivate():
+    global _active
+    if _active:
+        _active = False
+        new_meta_path = [i for i in sys.meta_path if i is not RewriteImporter]
+        assert len(new_meta_path) == len(sys.meta_path) - 1
+        sys.meta_path[:] = new_meta_path
+
+        new_passes = [p for p in module_passes if not isinstance(p, InstrumentationPass)]
+        assert len(new_passes) == len(module_passes) - 1
+        module_passes[:] = new_passes
+
+def clean_up():
+    INFO.clear()
+
+

--- a/ast_tools/passes/__init__.py
+++ b/ast_tools/passes/__init__.py
@@ -3,5 +3,6 @@ from .base import * # This MUST be first
 from .bool_to_bit import *
 from .debug import *
 from .if_to_phi import *
+from .instrumentation import *
 from .ssa import *
 from .util import *

--- a/ast_tools/passes/base.py
+++ b/ast_tools/passes/base.py
@@ -1,12 +1,12 @@
 from abc import ABCMeta, abstractmethod
-import ast
 import typing as tp
 
+from ast_tools import immutable_ast as iast
 from ast_tools.stack import SymbolTable
 
 __ALL__ = ['Pass', 'PASS_ARGS_T']
 
-PASS_ARGS_T = tp.Tuple[ast.AST, SymbolTable, tp.MutableMapping]
+PASS_ARGS_T = tp.Tuple[iast.AST, SymbolTable, tp.MutableMapping]
 
 class Pass(metaclass=ABCMeta):
     """
@@ -20,7 +20,7 @@ class Pass(metaclass=ABCMeta):
     @abstractmethod
     def rewrite(self,
             env: SymbolTable,
-            tree: ast.AST,
+            tree: iast.AST,
             metadata: tp.MutableMapping,
             ) -> PASS_ARGS_T:
 

--- a/ast_tools/passes/bool_to_bit.py
+++ b/ast_tools/passes/bool_to_bit.py
@@ -1,15 +1,14 @@
-import ast
 import typing as tp
 
 from . import Pass
 from . import PASS_ARGS_T
-
+from ast_tools import immutable_ast as iast
 from ast_tools.stack import SymbolTable
 
 __ALL__ = ['bool_to_bit']
 
-class BoolOpTransformer(ast.NodeTransformer):
-    def visit_BoolOp(self, node: ast.BoolOp) -> ast.expr:
+class BoolOpTransformer(iast.NodeTransformer):
+    def visit_BoolOp(self, node: iast.BoolOp) -> iast.expr:
         # Can't get more specific on return type because if
         # len(node.values) == 1 (which it shouldn't be)
         # then the return type is expr otherwise
@@ -20,25 +19,25 @@ class BoolOpTransformer(ast.NodeTransformer):
             assert values # should not be empty
             expr = self.visit(values[0])
             for v in map(self.visit, values[1:]):
-                expr = ast.BinOp(expr, self.replace(), v)
+                expr = iast.BinOp(expr, self.replace(), v)
             return expr
         else:
             return self.generic_visit(node)
 
 
 class AndTransformer(BoolOpTransformer):
-    match = ast.And
-    replace = ast.BitAnd
+    match = iast.And
+    replace = iast.BitAnd
 
 
 class OrTransformer(BoolOpTransformer):
-    match = ast.Or
-    replace = ast.BitOr
+    match = iast.Or
+    replace = iast.BitOr
 
 
-class NotTransformer(ast.NodeTransformer):
-    def visit_Not(self, node: ast.Not) -> ast.Invert:
-        return ast.Invert()
+class NotTransformer(iast.NodeTransformer):
+    def visit_Not(self, node: iast.Not) -> iast.Invert:
+        return iast.Invert()
 
 
 class bool_to_bit(Pass):
@@ -56,7 +55,7 @@ class bool_to_bit(Pass):
         self.replace_not = replace_not
 
     def rewrite(self,
-            tree: ast.AST,
+            tree: iast.AST,
             env: SymbolTable,
             metadata: tp.MutableMapping) -> PASS_ARGS_T:
         if self.replace_and:

--- a/ast_tools/passes/debug.py
+++ b/ast_tools/passes/debug.py
@@ -6,6 +6,7 @@ import astor
 
 from . import Pass
 from . import PASS_ARGS_T
+from ast_tools import immutable_ast as iast
 from ast_tools.stack import SymbolTable
 
 __ALL__ = ['debug']
@@ -31,7 +32,7 @@ class debug(Pass):
         self.dump_source_lines = dump_source_lines
 
     def rewrite(self,
-            tree: ast.AST,
+            tree: iast.AST,
             env: SymbolTable,
             metadata: tp.MutableMapping,
             ) -> PASS_ARGS_T:
@@ -43,10 +44,13 @@ class debug(Pass):
                 dump_writer(f'\nEND {dump[0]}\n\n')
 
         dumps = []
-        if self.dump_ast:
-            dumps.append(('AST', astor.dump_tree(tree)))
-        if self.dump_src:
-            dumps.append(('SRC', astor.to_source(tree)))
+        if self.dump_ast or self.dump_src:
+            tree_ = iast.mutable(tree)
+            if self.dump_ast:
+                dumps.append(('AST', astor.dump_tree(tree_)))
+            if self.dump_src:
+                dumps.append(('SRC', astor.to_source(tree_)))
+
         if self.dump_env:
             dumps.append(('ENV', repr(env)))
         if self.dump_source_filename:

--- a/ast_tools/passes/if_to_phi.py
+++ b/ast_tools/passes/if_to_phi.py
@@ -1,28 +1,27 @@
-import ast
 import warnings
 import typing as tp
 
 from . import Pass
 from . import PASS_ARGS_T
-
+from ast_tools import immutable_ast as iast
 from ast_tools.common import gen_free_name
 from ast_tools.stack import SymbolTable
 
 __ALL__ = ['if_to_phi']
 
 
-class IfExpTransformer(ast.NodeTransformer):
+class IfExpTransformer(iast.NodeTransformer):
     def __init__(self, phi_name: str):
         self.phi_name = phi_name
 
-    def visit_IfExp(self, node: ast.IfExp):
+    def visit_IfExp(self, node: iast.IfExp):
         test = self.visit(node.test)
         body = self.visit(node.body)
         orelse = self.visit(node.orelse)
-        return ast.Call(
-                func=ast.Name(
+        return iast.Call(
+                func=iast.Name(
                     id=self.phi_name,
-                    ctx=ast.Load()
+                    ctx=iast.Load()
                 ),
                 args=[test, body, orelse],
                 keywords=[]
@@ -52,7 +51,7 @@ class if_to_phi(Pass):
         self.phi_name_prefix = phi_name_prefix
 
     def rewrite(self,
-            tree: ast.AST,
+            tree: iast.AST,
             env: SymbolTable,
             metadata: tp.MutableMapping) -> PASS_ARGS_T:
 

--- a/ast_tools/passes/instrumentation.py
+++ b/ast_tools/passes/instrumentation.py
@@ -1,4 +1,5 @@
 import typing as tp
+import weakref
 
 from ast_tools import immutable_ast as iast
 from ast_tools.common import gen_free_name
@@ -7,7 +8,7 @@ from . import Pass
 from . import PASS_ARGS_T
 import sys
 
-INFO = {}
+INFO = weakref.WeakKeyDictionary()
 
 def dump_with_module(tree: iast.AST, module: str):
     '''

--- a/ast_tools/passes/instrumentation.py
+++ b/ast_tools/passes/instrumentation.py
@@ -1,0 +1,89 @@
+import typing as tp
+
+from ast_tools import immutable_ast as iast
+from ast_tools.common import gen_free_name
+from ast_tools.stack import SymbolTable
+from . import Pass
+from . import PASS_ARGS_T
+import sys
+
+INFO = {}
+
+def dump_with_module(tree: iast.AST, module: str):
+    '''
+    Basically dump but prepend module to class names
+    so that it can be eval'ed:
+        import ast
+        from ast_tools import immutable_ast as iast
+        t = ast.parse(...)
+        t2 = eval(dump_with_module(t, 'ast'))
+        assert iast.immutable(t) == iast.immutable(t2)
+    '''
+    head = f'{module}.{type(tree).__name__}('
+    tail = ')'
+    body = []
+    for field, value in iast.iter_fields(tree):
+        if isinstance(value, iast.AST):
+            value = dump_with_module(value, module)
+        elif isinstance(value, iast.S_NODE):
+            value = (dump_with_module(e, module) for e in value)
+            value = '[' + ', '.join(value) + ']'
+        else:
+            value = repr(value)
+        body.append(f'{field}={value}')
+    body = ', '.join(body)
+
+    return head + body + tail
+
+
+class Instrumentator(iast.NodeTransformer):
+    def __init__(self, import_name, env_name):
+        self.import_name = import_name
+        self.env_name = env_name
+
+    def handle_def(self, node: iast.stmt):
+        new_node = self.generic_visit(node)
+
+
+        # store locals global
+        env_node = iast.parse(f'{self.env_name} = locals(), globals()').body[0]
+
+        # import ast_tools
+        import_node = iast.Import(
+            names=[iast.alias('ast_tools', self.import_name)]
+        )
+
+        # store the ast and env
+        store_node = iast.parse(f'''
+{self.import_name}.instrumentation.INFO[{new_node.name}] = {{
+    'ast': {dump_with_module(node, self.import_name + '.immutable_ast')},
+    'env': {self.env_name},
+}}''').body[0]
+
+        # del ast_tools /  env
+        del_node = iast.Delete(targets=[
+            iast.Name(self.import_name,  iast.Del()),
+            iast.Name(self.env_name, iast.Del()),
+            ])
+        return [env_node, new_node, import_node, store_node, del_node]
+
+    def visit_ClassDef(self, node: iast.ClassDef):
+        return self.handle_def(node)
+
+    def visit_FunctionDef(self, node: iast.FunctionDef):
+        return self.handle_def(node)
+
+    def visit_AsyncFunctionDef(self, node: iast.AsyncFunctionDef):
+        return self.handle_def(node)
+
+class InstrumentationPass(Pass):
+    def rewrite(self,
+            tree: iast.AST,
+            env: SymbolTable,
+            metadata: tp.MutableMapping,
+            ) -> PASS_ARGS_T:
+        import_name = gen_free_name(tree, env, 'ast_tools')
+        env_name = gen_free_name(tree, env, 'env')
+        instrumentator = Instrumentator(import_name, env_name)
+        tree = instrumentator.visit(tree)
+        return tree, env, metadata

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -1,16 +1,16 @@
-import ast
 from collections import ChainMap, Counter
 import typing as tp
 
 from . import Pass
 from . import PASS_ARGS_T
+from ast_tools import immutable_ast as iast
 from ast_tools.common import gen_free_prefix, is_free_name
 from ast_tools.stack import SymbolTable
 from ast_tools.transformers import Renamer
 
 __ALL__ = ['ssa']
 
-class SSATransformer(ast.NodeTransformer):
+class SSATransformer(iast.NodeTransformer):
     def __init__(self, env, return_value_prefx):
         self.env = env
         self.name_idx = Counter()
@@ -39,12 +39,12 @@ class SSATransformer(ast.NodeTransformer):
         return name
 
 
-    def visit(self, node: ast.AST) -> ast.AST:
+    def visit(self, node: iast.AST) -> iast.AST:
         # basically want to able to visit a top level function
         # but don't want to generally recurse into them
         if self.root is None:
             self.root = node
-            if isinstance(node, ast.FunctionDef):
+            if isinstance(node, iast.FunctionDef):
                 for arg in node.args.args:
                     arg_name = arg.arg
                     self.name_table[arg_name] = arg_name
@@ -59,12 +59,12 @@ class SSATransformer(ast.NodeTransformer):
 
     def visit_Assign(self, node):
         # visit RHS first
-        node.value = self.visit(node.value)
-        node.targets = [self.visit(t) for t in node.targets]
-        return node
+        value = self.visit(node.value)
+        targets = [self.visit(t) for t in node.targets]
+        return iast.Assign(targets, value)
 
 
-    def visit_If(self, node: ast.If) -> tp.List[ast.stmt]:
+    def visit_If(self, node: iast.If) -> tp.List[iast.stmt]:
         test = self.visit(node.test)
         nt = self.name_table
         suite = []
@@ -111,7 +111,7 @@ class SSATransformer(ast.NodeTransformer):
         # should become:
         #   return 0 if x and y else 1 if not x else 2
         if not t_returns:
-            self.cond_stack.append(ast.UnaryOp(ast.Not(), test))
+            self.cond_stack.append(iast.UnaryOp(iast.Not(), test))
 
         self.name_table = f_nt = nt.new_child()
 
@@ -171,20 +171,20 @@ class SSATransformer(ast.NodeTransformer):
         else:
             # mux names
             def _build_name(name):
-                return ast.Name(
+                return iast.Name(
                         id=name,
-                        ctx=ast.Load(),
+                        ctx=iast.Load(),
                     )
 
             def _mux_name(name, t_name, f_name):
-                return ast.Assign(
+                return iast.Assign(
                         targets=[
-                            ast.Name(
+                            iast.Name(
                                 id=self._make_name(name),
-                                ctx=ast.Store(),
+                                ctx=iast.Store(),
                             ),
                         ],
-                        value=ast.IfExp(
+                        value=iast.IfExp(
                             test=test,
                             body=_build_name(t_name),
                             orelse=_build_name(f_name),
@@ -206,66 +206,66 @@ class SSATransformer(ast.NodeTransformer):
         return suite
 
 
-    def visit_Name(self, node: ast.Name) -> ast.Name:
+    def visit_Name(self, node: iast.Name) -> iast.Name:
         name = node.id
         ctx = node.ctx
-        if isinstance(ctx, ast.Load):
+        if isinstance(ctx, iast.Load):
             # Names in Load context should not be added to the name table
             # as it makes them seem like they have been modified.
             try:
-                return ast.Name(
+                return iast.Name(
                         id=self.name_table[name],
                         ctx=ctx)
             except KeyError:
                 pass
-            return ast.Name(
+            return iast.Name(
                     id=name,
                     ctx=ctx)
         else:
-            return ast.Name(
+            return iast.Name(
                     id=self._make_name(name),
                     ctx=ctx)
 
 
-    def visit_Return(self, node: ast.Return) -> ast.Assign:
+    def visit_Return(self, node: iast.Return) -> iast.Assign:
         r_val = self.visit(node.value)
         r_name = self._make_return()
         self.returns.append((list(self.cond_stack), r_name))
-        return ast.Assign(
-            targets=[ast.Name(r_name, ast.Store())],
+        return iast.Assign(
+            targets=[iast.Name(r_name, iast.Store())],
             value=r_val,
         )
 
 
     # don't support control flow other than if
-    def visit_For(self, node: ast.For):
+    def visit_For(self, node: iast.For):
         raise SyntaxError(f"Cannot handle node {node}")
 
-    def visit_AsyncFor(self, node: ast.AsyncFor):
+    def visit_AsyncFor(self, node: iast.AsyncFor):
         raise SyntaxError(f"Cannot handle node {node}")
 
-    def visit_While(self, node: ast.While):
+    def visit_While(self, node: iast.While):
         raise SyntaxError(f"Cannot handle node {node}")
 
-    def visit_With(self, node: ast.With):
+    def visit_With(self, node: iast.With):
         raise SyntaxError(f"Cannot handle node {node}")
 
-    def visit_AsyncWith(self, node: ast.AsyncWith):
+    def visit_AsyncWith(self, node: iast.AsyncWith):
         raise SyntaxError(f"Cannot handle node {node}")
 
-    def visit_Try(self, node: ast.Try):
+    def visit_Try(self, node: iast.Try):
         raise SyntaxError(f"Cannot handle node {node}")
 
     # don't recurs into defs, but do rename them
-    def visit_ClassDef(self, node: ast.ClassDef):
+    def visit_ClassDef(self, node: iast.ClassDef):
         renamer = Renamer(self.name_table.new_child())
         return renamer.visit(node)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef):
+    def visit_FunctionDef(self, node: iast.FunctionDef):
         renamer = Renamer(self.name_table.new_child())
         return renamer.visit(node)
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+    def visit_AsyncFunctionDef(self, node: iast.AsyncFunctionDef):
         renamer = Renamer(self.name_table.new_child())
         return renamer.visit(node)
 
@@ -273,15 +273,15 @@ class SSATransformer(ast.NodeTransformer):
 def _prove_names_defined(
         env: SymbolTable,
         names: tp.AbstractSet[str],
-        node: tp.Union[ast.AST, tp.Sequence[ast.AST]]) -> tp.AbstractSet[str]:
+        node: tp.Union[iast.AST, tp.Sequence[iast.AST]]) -> tp.AbstractSet[str]:
     '''
     Prove that all names are defined.
     i.e. if a name is used at some point then all paths leading to that point
     must either return or define the name.
     '''
     names = set(names)
-    if isinstance(node, ast.Name):
-        if isinstance(node.ctx, ast.Store):
+    if isinstance(node, iast.Name):
+        if isinstance(node.ctx, iast.Store):
             names.add(node.id)
         elif node.id not in names and node.id not in env and \
                 node.id not in env["__builtins__"].__dict__:
@@ -290,7 +290,7 @@ def _prove_names_defined(
             else:
                 raise SyntaxError(f'Cannot prove name, {node.id}, is defined')
 
-    elif isinstance(node, ast.If):
+    elif isinstance(node, iast.If):
         t_returns = _always_returns(node.body)
         f_returns = _always_returns(node.orelse)
         t_names = _prove_names_defined(env, names, node.body)
@@ -301,8 +301,8 @@ def _prove_names_defined(
             names |= f_names
         elif f_returns:
             names |= t_names
-    elif isinstance(node, ast.AST):
-        for child in ast.iter_child_nodes(node):
+    elif isinstance(node, iast.AST):
+        for child in iast.iter_child_nodes(node):
             names |= _prove_names_defined(env, names, child)
     else:
         assert isinstance(node, tp.Sequence)
@@ -311,14 +311,14 @@ def _prove_names_defined(
     return names
 
 
-def _always_returns(body: tp.Sequence[ast.stmt]) -> bool:
+def _always_returns(body: tp.Sequence[iast.stmt]) -> bool:
     '''
     Determine if some sequence of statements always reaches a return
     '''
     for stmt in body:
-        if isinstance(stmt, ast.Return):
+        if isinstance(stmt, iast.Return):
             return True
-        elif isinstance(stmt, ast.If):
+        elif isinstance(stmt, iast.If):
             if _always_returns(stmt.body) and _always_returns(stmt.orelse):
                 return True
 
@@ -326,19 +326,19 @@ def _always_returns(body: tp.Sequence[ast.stmt]) -> bool:
 
 
 def _build_return(
-        returns: tp.Sequence[tp.Tuple[tp.List[ast.expr], str]]) -> ast.expr:
+        returns: tp.Sequence[tp.Tuple[tp.List[iast.expr], str]]) -> iast.expr:
     '''
     "Fold" ifExpr over a Sequence of conditons and names
     '''
     assert returns
     conditions, name = returns[0]
-    name = ast.Name(id=name, ctx=ast.Load())
+    name = iast.Name(id=name, ctx=iast.Load())
     if not conditions:
         return name
     else:
-        expr = ast.IfExp(
-            test=ast.BoolOp(
-                op=ast.And(),
+        expr = iast.IfExp(
+            test=iast.BoolOp(
+                op=iast.And(),
                 values=conditions,
             ),
             body=name,
@@ -353,17 +353,17 @@ class ssa(Pass):
         self.return_prefix = return_prefix
 
     def rewrite(self,
-            tree: ast.AST,
+            tree: iast.AST,
             env: SymbolTable,
             metadata: tp.MutableMapping) -> PASS_ARGS_T:
-        if not isinstance(tree, ast.FunctionDef):
+        if not isinstance(tree, iast.FunctionDef):
             raise TypeError('ssa should only be applied to functions')
         r_name = gen_free_prefix(tree, env, self.return_prefix)
         visitor = SSATransformer(env, r_name)
         tree = visitor.visit(tree)
-        tree.body.append(
-            ast.Return(
+        tree = tree.replace(body=tree.body+
+            (iast.Return(
                 value=_build_return(visitor.returns)
-            )
+            ),)
         )
         return tree, env, metadata

--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -25,7 +25,11 @@ class begin_rewrite:
         if fn in INFO:
             info = INFO[fn]
             tree = info['ast']
-            self.env = SymbolTable(*info['env'])
+            try:
+                self.env = SymbolTable(*info['env'])
+            except KeyError():
+                pass
+
             if self.clean_up:
                 del INFO[fn]
         else:

--- a/ast_tools/transformers/renamer.py
+++ b/ast_tools/transformers/renamer.py
@@ -1,18 +1,15 @@
-import ast
 import typing as tp
 
+from ast_tools import immutable_ast as iast
 
-class Renamer(ast.NodeTransformer):
+class Renamer(iast.NodeTransformer):
     def __init__(self, name_map: tp.Mapping[str, str]):
         self.name_map = name_map
 
     def visit_Name(self, node):
         name = node.id
         new_name = self.name_map.setdefault(name, name)
-        return ast.copy_location(
-            ast.Name(
+        return iast.Name(
                 id=new_name,
                 ctx=node.ctx,
-            ),
-            node,
-        )
+            )

--- a/ast_tools/visitors/collect_names.py
+++ b/ast_tools/visitors/collect_names.py
@@ -2,10 +2,10 @@
 Defines a visitor that collects all names contained in an AST
 """
 
-import ast
+from ast_tools import immutable_ast as iast
 
 
-class NameCollector(ast.NodeVisitor):
+class NameCollector(iast.NodeVisitor):
     """
     Collect all instances of `Name` in an AST
     """

--- a/ast_tools/visitors/used_names.py
+++ b/ast_tools/visitors/used_names.py
@@ -1,24 +1,25 @@
-import ast
 from functools import lru_cache
 
-class UsedNames(ast.NodeVisitor):
+from ast_tools import immutable_ast as iast
+
+class UsedNames(iast.NodeVisitor):
     def __init__(self):
         self.names = set()
 
-    def visit_Name(self, node: ast.Name):
+    def visit_Name(self, node: iast.Name):
         self.names.add(node.id)
 
-    def visit_FunctionDef(self, node: ast.FunctionDef):
+    def visit_FunctionDef(self, node: iast.FunctionDef):
         self.names.add(node.name)
 
-    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef):
+    def visit_AsyncFunctionDef(self, node: iast.AsyncFunctionDef):
         self.names.add(node.name)
 
-    def visit_ClassDef(self, node: ast.ClassDef):
+    def visit_ClassDef(self, node: iast.ClassDef):
         self.names.add(node.name)
 
 @lru_cache()
-def used_names(tree: ast.AST):
+def used_names(tree: iast.AST):
     visitor = UsedNames()
     visitor.visit(tree)
     return visitor.names

--- a/tests/target.py
+++ b/tests/target.py
@@ -1,0 +1,18 @@
+__ALL__ = ['F', 'f', 'G', 'g', 'h']
+class F: pass
+
+def f(x):
+    return x
+
+@f
+class G: pass
+
+@f
+def g(): pass
+
+def h():
+    local_var = 1
+    def h_():
+        pass
+    return h_
+

--- a/tests/target2.py
+++ b/tests/target2.py
@@ -1,0 +1,18 @@
+__ALL__ = ['F', 'f', 'G', 'g', 'h']
+class F: pass
+
+def f(x):
+    return x
+
+@f
+class G: pass
+
+@f
+def g(): pass
+
+def h():
+    local_var = 1
+    def h_():
+        pass
+    return h_
+

--- a/tests/target2.py
+++ b/tests/target2.py
@@ -1,18 +1,32 @@
-__ALL__ = ['F', 'f', 'G', 'g', 'h']
-class F: pass
+from ast_tools import passes
+from ast_tools.instrumentation import INFO
 
-def f(x):
-    return x
+class debug_begin(passes.begin_rewrite):
+    def __call__(self, fn):
+        assert fn in INFO
+        return super().__call__(fn)
 
-@f
-class G: pass
+@passes.end_rewrite()
+@debug_begin()
+def f(): pass
 
-@f
-def g(): pass
+def g():
+    @passes.end_rewrite()
+    @debug_begin()
+    def h(): pass
+    return h
 
-def h():
-    local_var = 1
-    def h_():
-        pass
-    return h_
+@passes.end_rewrite()
+@debug_begin()
+class A: pass
+
+class B:
+    @passes.end_rewrite()
+    @debug_begin()
+    class C: pass
+
+    @passes.end_rewrite()
+    @debug_begin()
+    def method(self): pass
+
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,4 @@
-import ast
-import astor
-
+from ast_tools import immutable_ast as iast
 from ast_tools.common import get_ast, gen_free_name, gen_free_prefix
 from ast_tools.stack import SymbolTable
 from ast_tools.passes import begin_rewrite, end_rewrite
@@ -9,9 +7,9 @@ from ast_tools.passes import begin_rewrite, end_rewrite
 def test_get_ast():
     def f(): pass
     f_str = 'def f(): pass'
-    ast_str_0 = astor.dump_tree(get_ast(f))
-    ast_str_1 = astor.dump_tree(ast.parse(f_str).body[0])
-    assert ast_str_0 == ast_str_1
+    ast_0 = get_ast(f)
+    ast_1 = iast.parse(f_str)
+    assert ast_0 == ast_1.body[0]
 
 
 def test_gen_free_name():
@@ -23,7 +21,7 @@ def P0():
     return P.P5
 P1 = P0()
 '''
-    tree = ast.parse(src)
+    tree = iast.parse(src)
     env = SymbolTable({}, {})
 
     free_name = gen_free_name(tree, env)
@@ -47,7 +45,7 @@ def P0():
     return P.P5
 P1 = P0()
 '''
-    tree = ast.parse(src)
+    tree = iast.parse(src)
     env = SymbolTable({}, {})
 
     free_prefix = gen_free_prefix(tree, env)

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,39 +1,57 @@
 import pytest
+import importlib
+import sys
 
 from ast_tools import instrumentation
 from ast_tools.common import get_ast
 from ast_tools import immutable_ast as iast
 import target
-instrumentation.activate()
 import target2
 
 assert target.__ALL__ == target2.__ALL__
 
+def _reset():
+    del sys.modules['target2']
+    importlib.invalidate_caches()
+
+_reset()
+
 @pytest.mark.parametrize("name", target.__ALL__)
 def test_basic(name):
+    instrumentation.activate(False)
+    import target2
     def_g = getattr(target, name)
     def_i = getattr(target2, name)
     g_tree = get_ast(def_g)
     i_tree = instrumentation.INFO[def_i]['ast']
+    assert 'env' not in instrumentation.INFO[def_i]
     if isinstance(i_tree, iast.ClassDef):
         # inspect doesn't get the decorator_list for classes
         i_tree = i_tree.replace(decorator_list=())
     assert i_tree == g_tree
+    instrumentation.deactivate()
+    _reset()
 
 @pytest.mark.parametrize("name", target.__ALL__)
 def test_env(name):
+    instrumentation.activate(True)
+    import target2
     seen = {}
     def_ = getattr(target2, name)
     assert set(target2.__ALL__) <= instrumentation.INFO[def_]['env'][0].keys()
+    instrumentation.deactivate()
+    _reset()
 
 
 def test_closure():
+    instrumentation.activate(True)
+    import target2
     def_g = target.h()
     def_i = target2.h()
     g_tree = get_ast(def_g)
     i_tree = instrumentation.INFO[def_i]['ast']
     assert i_tree == g_tree
     assert instrumentation.INFO[def_i]['env'][0]['local_var'] == 1
+    instrumentation.deactivate()
+    _reset()
 
-
-instrumentation.deactivate()

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -5,23 +5,20 @@ import sys
 from ast_tools import instrumentation
 from ast_tools.common import get_ast
 from ast_tools import immutable_ast as iast
-import target
-import target2
-
-assert target.__ALL__ == target2.__ALL__
 
 def _reset():
-    del sys.modules['target2']
+    del sys.modules['target']
     importlib.invalidate_caches()
 
+import target as base_target
 _reset()
 
-@pytest.mark.parametrize("name", target.__ALL__)
+@pytest.mark.parametrize("name", base_target.__ALL__)
 def test_basic(name):
     instrumentation.activate(False)
-    import target2
-    def_g = getattr(target, name)
-    def_i = getattr(target2, name)
+    import target
+    def_g = getattr(base_target, name)
+    def_i = getattr(target, name)
     g_tree = get_ast(def_g)
     i_tree = instrumentation.INFO[def_i]['ast']
     assert 'env' not in instrumentation.INFO[def_i]
@@ -32,26 +29,34 @@ def test_basic(name):
     instrumentation.deactivate()
     _reset()
 
-@pytest.mark.parametrize("name", target.__ALL__)
+@pytest.mark.parametrize("name", base_target.__ALL__)
 def test_env(name):
     instrumentation.activate(True)
-    import target2
+    import target
     seen = {}
-    def_ = getattr(target2, name)
-    assert set(target2.__ALL__) <= instrumentation.INFO[def_]['env'][0].keys()
+    def_ = getattr(target, name)
+    assert set(target.__ALL__) <= instrumentation.INFO[def_]['env'][0].keys()
     instrumentation.deactivate()
     _reset()
 
 
 def test_closure():
     instrumentation.activate(True)
-    import target2
-    def_g = target.h()
-    def_i = target2.h()
+    import target
+    def_g = base_target.h()
+    def_i = target.h()
     g_tree = get_ast(def_g)
     i_tree = instrumentation.INFO[def_i]['ast']
     assert i_tree == g_tree
     assert instrumentation.INFO[def_i]['env'][0]['local_var'] == 1
     instrumentation.deactivate()
     _reset()
+
+def test_passes():
+    instrumentation.activate(True)
+    import target2
+    target2.g()
+    target2.A()
+    target2.B()
+    target2.B.C()
 

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ast_tools import instrumentation
+from ast_tools.common import get_ast
+from ast_tools import immutable_ast as iast
+import target
+instrumentation.activate()
+import target2
+
+assert target.__ALL__ == target2.__ALL__
+
+@pytest.mark.parametrize("name", target.__ALL__)
+def test_basic(name):
+    def_g = getattr(target, name)
+    def_i = getattr(target2, name)
+    g_tree = get_ast(def_g)
+    i_tree = instrumentation.INFO[def_i]['ast']
+    if isinstance(i_tree, iast.ClassDef):
+        # inspect doesn't get the decorator_list for classes
+        i_tree = i_tree.replace(decorator_list=())
+    assert i_tree == g_tree
+
+@pytest.mark.parametrize("name", target.__ALL__)
+def test_env(name):
+    seen = {}
+    def_ = getattr(target2, name)
+    assert set(target2.__ALL__) <= instrumentation.INFO[def_]['env'][0].keys()
+
+
+def test_closure():
+    def_g = target.h()
+    def_i = target2.h()
+    g_tree = get_ast(def_g)
+    i_tree = instrumentation.INFO[def_i]['ast']
+    assert i_tree == g_tree
+    assert instrumentation.INFO[def_i]['env'][0]['local_var'] == 1
+
+
+instrumentation.deactivate()

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,7 +1,7 @@
 """
 Test collecting instances of `ast.Name`
 """
-import ast
+from ast_tools import immutable_ast as iast
 from ast_tools.visitors import collect_names
 from ast_tools.visitors import UsedNames
 
@@ -15,14 +15,14 @@ def foo(bar, baz):  # pylint: disable=blacklisted-name
     return buzz
 '''
 
-    foo_ast = ast.parse(s)
+    foo_ast = iast.parse(s)
     assert collect_names(foo_ast) == {"bar", "baz", "buzz"}
-    assert collect_names(foo_ast, ctx=ast.Load) == {"bar", "baz", "buzz"}
-    assert collect_names(foo_ast, ctx=ast.Store) == {"buzz"}
+    assert collect_names(foo_ast, ctx=iast.Load) == {"bar", "baz", "buzz"}
+    assert collect_names(foo_ast, ctx=iast.Store) == {"buzz"}
 
 
 def test_used_names():
-    tree =  ast.parse('''
+    tree =  iast.parse('''
 x = 1
 def foo():
     def g():

--- a/util/generate_ast/_base.px
+++ b/util/generate_ast/_base.px
@@ -1,4 +1,9 @@
 class AST(mutable=ast.AST, metaclass=ImmutableMeta):
+    def replace(self, **kwargs):
+        args = {field: getattr(self, field) for field in self._fields}
+        args.update(kwargs)
+        return type(self)(**args)
+
     def __setattr__(self, attr, value):
         if attr in self._fields and hasattr(self, attr):
             raise AttributeError('Cannot modify ImmutableAST fields')
@@ -31,9 +36,9 @@ class AST(mutable=ast.AST, metaclass=ImmutableMeta):
         return h
 
     def __eq__(self, other):
-        if not isinstance(other, type(self)):
+        if not isinstance(other, AST):
             return NotImplemented
-        elif type(self) == type(other):
+        elif isinstance(other, type(self)):
             for f in self._fields:
                 if getattr(self, f) != getattr(other, f):
                     return False

--- a/util/generate_ast/_base.px
+++ b/util/generate_ast/_base.px
@@ -1,6 +1,6 @@
 class AST(mutable=ast.AST, metaclass=ImmutableMeta):
     def replace(self, **kwargs):
-        args = {field: getattr(self, field) for field in self._fields}
+        args = dict(iter_fields(self))
         args.update(kwargs)
         return type(self)(**args)
 

--- a/util/generate_ast/_functions.px
+++ b/util/generate_ast/_functions.px
@@ -1,6 +1,6 @@
 __ALL__ += ['immutable', 'mutable', 'parse', 'dump',
-			'iter_fields', 'iter_child_nodes', 'walk',
-			'NodeVisitor', 'NodeTransformer']
+            'iter_fields', 'iter_child_nodes', 'walk',
+            'NodeVisitor', 'NodeTransformer']
 
 
 def _cast_tree(seq_t, n_seq_t, type_look_up, tree):
@@ -37,13 +37,15 @@ def dump(node, annotate_fields=True, include_attributes=False) -> str:
     tree = mutable(node)
     return ast.dump(tree)
 
+S_NODE = (list, tuple)
 
 # duck typing ftw
 iter_fields = ast.iter_fields
 
 # The following is more or less copied verbatim from
 # CPython/Lib/ast.py. Changes are:
-# s/list/tuple/
+#   s/list/S_NODE/
+#   where S_NODE = (list, tuple)
 #
 # The CPython license is very permissive so I am pretty sure this is cool.
 # If it is not Guido please forgive me.
@@ -51,7 +53,7 @@ def iter_child_nodes(node):
     for name, field in iter_fields(node):
         if isinstance(field, AST):
             yield field
-        elif isinstance(field, tuple):
+        elif isinstance(field, S_NODE):
             for item in field:
                 if isinstance(item, AST):
                     yield item
@@ -75,7 +77,7 @@ class NodeVisitor:
 
     def generic_visit(self, node):
         for field, value in iter_fields(node):
-            if isinstance(value,  tuple):
+            if isinstance(value,  S_NODE):
                 for item in value:
                     if isinstance(item, AST):
                         self.visit(item)
@@ -93,7 +95,7 @@ class NodeTransformer(NodeVisitor):
     def generic_visit(self, node):
         kwargs = {}
         for field, old_value in iter_fields(node):
-            if isinstance(old_value, tuple):
+            if isinstance(old_value, S_NODE):
                 new_value = []
                 for value in old_value:
                     if isinstance(value, AST):
@@ -105,7 +107,7 @@ class NodeTransformer(NodeVisitor):
                             continue
                     new_value.append(value)
                 new_value = tuple(new_value)
-            elif isinstance(type(old_value), ImmutableMeta):
+            elif isinstance(old_value, AST):
                 new_value = self.visit(old_value)
             else:
                 new_value = old_value


### PR DESCRIPTION
This pull request contains two major additions to #20 
* Adds importer which allows passes to be performed on all imported modules
* Adds a pass to instrument definitions with their locals, globals, and AST

The latter of these two additions removes the need for hackiness of `stack.get_symbol_table` and `inspect.getsource`