### PR TITLE
Issue 31

### DIFF
--- a/ast_tools/common.py
+++ b/ast_tools/common.py
@@ -28,7 +28,7 @@ def exec_def_in_file(
     execs a definition in a file and returns the definiton
     """
     if file_name is None:
-        file_name = tree.name + '.py'
+        file_name = tree.name + f'{hash(tree)}.py'
 
     return exec_in_file(tree, st, path, file_name)[tree.name]
 

--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -38,8 +38,8 @@ class end_rewrite(Pass):
     """
     ends a chain of passes
     """
-    def __init__(self, path: tp.Optional[str] = None):
-        self.path = path
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
 
     def rewrite(self,
             tree: ast.AST,
@@ -74,4 +74,4 @@ class end_rewrite(Pass):
 
         tree.decorator_list = reversed(decorators)
         tree = ast.fix_missing_locations(tree)
-        return exec_def_in_file(tree, env, self.path)
+        return exec_def_in_file(tree, env, **self.kwargs)

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -30,7 +30,7 @@ def foo():
 
 def test_debug(capsys):
 
-    @end_rewrite
+    @end_rewrite()
     @debug(dump_source_filename=True, dump_source_lines=True)
     @begin_rewrite(debug=True)
     def foo():
@@ -41,7 +41,7 @@ BEGIN SOURCE_FILENAME
 END SOURCE_FILENAME
 
 BEGIN SOURCE_LINES
-33:    @end_rewrite
+33:    @end_rewrite()
 34:    @debug(dump_source_filename=True, dump_source_lines=True)
 35:    @begin_rewrite(debug=True)
 36:    def foo():


### PR DESCRIPTION
resolves #31 

* Any arguments to init of end_rewrite shall be passed to exec_def_in_file
* By default append the hash of the tree to the name of the def being exec'd to make names unique
