### PR TITLE
Add strict flag to ssa

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -466,6 +466,10 @@ class ssa(Pass):
         if not isinstance(tree, ast.FunctionDef):
             raise TypeError('ssa should only be applied to functions')
 
+        # Going to use this in an assert later but need to get the info
+        # before any transformation happens
+        NR = _never_returns(tree.body)
+
         # Find all attributes that are written
         targets = collect_targets(tree, ast.Attribute)
         replacer = AttrReplacer({})
@@ -530,5 +534,5 @@ class ssa(Pass):
                 )
             )
         else:
-            assert _never_returns(tree.body)
+            assert NR
         return tree, env, metadata


### PR DESCRIPTION
* Allows ssa to operate on functions that never return. Note: never
    returning is different from returning None or having bare return
    statements.  This allows it to work on functions that communicate
    through side effects (writing attrs).

* Adds a strict flag which controls whether ssa errors on functions that
    could `NameError` or only sometimes return.  `ssa(False)` should be 
    equivalent to sequentials ssa transformation.  