### PR TITLE
Add basic AST pattern matching

### DIFF
--- a/ast_tools/pattern.py
+++ b/ast_tools/pattern.py
@@ -1,7 +1,6 @@
 import re
 import ast
 import itertools
-from astor import to_source as a2s
 
 # Globals dictionary to evaluate type names in node patterns
 eval_globals = {}

--- a/ast_tools/pattern.py
+++ b/ast_tools/pattern.py
@@ -2,10 +2,6 @@ import re
 import ast
 import itertools
 
-# Globals dictionary to evaluate type names in node patterns
-eval_globals = {}
-exec('from ast import *', eval_globals)
-
 
 class NodePattern:
     """An individual node match, e.g. {x:Name}"""
@@ -25,7 +21,7 @@ class NodePattern:
             self.type = None
         else:
             assert (len(parts) == 2)
-            self.type = eval(parts[1], eval_globals)
+            self.type = getattr(ast, parts[1])
 
 
 class ASTPattern:

--- a/ast_tools/pattern.py
+++ b/ast_tools/pattern.py
@@ -1,0 +1,110 @@
+import re
+import ast
+import itertools
+from astor import to_source as a2s
+
+# Globals dictionary to evaluate type names in node patterns
+eval_globals = {}
+exec('from ast import *', eval_globals)
+
+
+class NodePattern:
+    """An individual node match, e.g. {x:Name}"""
+    def __init__(self, s):
+        self._parse(s)
+
+    def _parse(self, s):
+        """
+        Extracts the name and type of the desired AST node.
+        If no type is provided, then self.type is None.
+
+        Type names are evaluated in a context with the ast module imported.
+        """
+        parts = tuple(s[1:-1].split(':'))
+        if len(parts) == 1:
+            self.name = parts[0]
+            self.type = None
+        else:
+            assert (len(parts) == 2)
+            self.name = parts[0]
+            self.type = eval(parts[1], eval_globals)
+
+
+class ASTPattern:
+    """
+    A pattern for an AST subtree.
+
+    Patterns are normal Python programs but with pieces replaced by NodePatterns.
+    For example, to match a copy statement (x = y) looks like:
+
+    {lhs:Name} = {rhs:Name}
+    """
+    def __init__(self, s):
+        self.template = self._parse(s)
+
+    def _parse(self, s):
+        """
+        Replace each node pattern with a unique variable name.
+        """
+        hole_id = 0
+        self.var_map = {}
+
+        def replace_incr(exp):
+            nonlocal hole_id
+            hole_id += 1
+            name = '__hole{}'.format(hole_id)
+            self.var_map[name] = NodePattern(exp.group(0))
+            return name
+
+        return ast.parse(re.sub(r'{[^}]*}', replace_incr, s)).body[0]
+
+    def _match(self, pattern_node, actual_node):
+        # If pattern_node is a lone variable (Expr of Name, or plain Name)
+        # then extract the variable name
+        if isinstance(pattern_node, ast.Name):
+            pattern_var = pattern_node.id
+        elif isinstance(pattern_node, ast.Expr) and \
+             isinstance(pattern_node.value, ast.Name):
+            pattern_var = pattern_node.value.id
+        else:
+            pattern_var = None
+
+        # Check if pattern variable name corresponds to a hole in var_map
+        if pattern_var is not None and pattern_var in self.var_map:
+            node_pattern = self.var_map[pattern_var]
+
+            # If the pattern variable type matches the actual node AST type,
+            # then save the match and return True
+            if node_pattern.type is None or \
+               isinstance(actual_node, node_pattern.type):
+                self._matches[node_pattern.name] = actual_node
+                return True
+            else:
+                return False
+
+        # Structural AST equality, adapted from
+        # https://stackoverflow.com/questions/3312989/elegant-way-to-test-python-asts-for-equality-not-reference-or-object-identity
+        if type(pattern_node) is not type(actual_node):
+            return False
+        if isinstance(pattern_node, ast.AST):
+            for k, v in vars(pattern_node).items():
+                if k in ('lineno', 'col_offset', 'ctx', '_pp'):
+                    continue
+                if not self._match(v, getattr(actual_node, k)):
+                    return False
+            return True
+        elif isinstance(pattern_node, list):
+            return all(itertools.starmap(self._match, zip(pattern_node, actual_node)))
+        else:
+            return pattern_node == actual_node
+
+    def match(self, node):
+        self._matches = {}
+        if self._match(self.template, node):
+            return self._matches.copy()
+        else:
+            return None
+
+
+def ast_match(pattern, node):
+    return ASTPattern(pattern).match(node)

--- a/ast_tools/pattern.py
+++ b/ast_tools/pattern.py
@@ -20,12 +20,11 @@ class NodePattern:
         Type names are evaluated in a context with the ast module imported.
         """
         parts = tuple(s[1:-1].split(':'))
+        self.name = parts[0]
         if len(parts) == 1:
-            self.name = parts[0]
             self.type = None
         else:
             assert (len(parts) == 2)
-            self.name = parts[0]
             self.type = eval(parts[1], eval_globals)
 
 
@@ -78,8 +77,7 @@ class ASTPattern:
                isinstance(actual_node, node_pattern.type):
                 self._matches[node_pattern.name] = actual_node
                 return True
-            else:
-                return False
+            return False
 
         # Structural AST equality, adapted from
         # https://stackoverflow.com/questions/3312989/elegant-way-to-test-python-asts-for-equality-not-reference-or-object-identity
@@ -94,15 +92,13 @@ class ASTPattern:
             return True
         elif isinstance(pattern_node, list):
             return all(itertools.starmap(self._match, zip(pattern_node, actual_node)))
-        else:
-            return pattern_node == actual_node
+        return pattern_node == actual_node
 
     def match(self, node):
         self._matches = {}
         if self._match(self.template, node):
             return self._matches.copy()
-        else:
-            return None
+        return None
 
 
 def ast_match(pattern, node):

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -61,7 +61,5 @@ else:
     match1 = parse_match(pattern, stmt1)
     assert match1 is not None
 
-    print(match1)
-
     match2 = parse_match(pattern, stmt2)
     assert match2 is None

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -1,0 +1,67 @@
+import ast
+
+from ast_tools.pattern import ast_match
+from ast_tools.common import get_ast
+
+
+def parse_match(pattern, stmt):
+    return ast_match(pattern, ast.parse(stmt).body[0])
+
+
+def test_pattern_assign_copy():
+    stmt1 = "x = y"
+    stmt2 = "x = 1"
+
+    pattern = "{lhs:Name} = {rhs:Name}"
+    match1 = parse_match(pattern, stmt1)
+    assert match1 is not None
+    assert match1['lhs'].id == 'x'
+    assert match1['rhs'].id == 'y'
+
+    match2 = parse_match(pattern, stmt2)
+    assert match2 is None
+
+
+def test_pattern_assign_number():
+    stmt1 = "x = y"
+    stmt2 = "x = 1"
+
+    pattern = "{lhs:Name} = {rhs:Num}"
+    match1 = parse_match(pattern, stmt1)
+    assert match1 is None
+
+    match2 = parse_match(pattern, stmt2)
+    assert match2 is not None
+    assert match2['lhs'].id == 'x'
+    assert match2['rhs'].n == 1
+
+
+def test_pattern_if():
+    stmt1 = """
+if x:
+    y = 1
+else:
+    z = 1
+"""
+
+    stmt2 = """
+if x:
+    print(y)
+else:
+    z = 1
+"""
+
+    pattern = """
+if {cond:Name}:
+    {then_:Assign}
+else:
+    {else_}
+"""
+
+    match1 = parse_match(pattern, stmt1)
+    assert match1 is not None
+
+    print(match1)
+
+    match2 = parse_match(pattern, stmt2)
+    assert match2 is None


### PR DESCRIPTION
This is a feature I've used frequently in my inliner tool, and I figured it would be a good first contribution to `ast_tools` :-)

This is an API for [comby-like](https://comby.dev/) structural pattern matching on ASTs, but native to Python. Here's an example:

```python
stmt = "x = y"
pattern = "{lhs:Name} = {rhs:Name}"

match = ast_match(pattern, ast.parse(stmt).body[0]))
assert match is not None
assert match['lhs'].id == 'x'
```

The implementation is fairly simple. The pattern language is a normal Python program, except with holes denoted by curly braces. Each hole is replaced with a dummy variable, and the resultant program is parsed into a pattern AST. This is structurally compared against a target AST, and holes are filled during the comparison.

Right now the library only works for small statements. It doesn't have Kleene star or any kind of fancier pattern stuff. Open to ideas for how to add that in.

Let me know if this seems like something y'all would find useful, or if you have any comments on how to improve it.