### PR TITLE
change default free name prefix

### DIFF
--- a/ast_tools/common.py
+++ b/ast_tools/common.py
@@ -108,7 +108,7 @@ def gen_free_name(
     if prefix is not None and prefix not in names:
         return prefix
     elif prefix is None:
-        prefix = '__auto_name_'
+        prefix = '_auto_name_'
 
     f_str = prefix+'{}'
     c = 0
@@ -132,7 +132,7 @@ def gen_free_prefix(
     if preprefix is not None and check_prefix(preprefix, names):
         return preprefix
     elif preprefix is None:
-        preprefix = '__auto_prefix_'
+        preprefix = '_auto_prefix_'
 
     f_str = preprefix+'{}'
     c = 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -27,7 +27,7 @@ P1 = P0()
     env = SymbolTable({}, {})
 
     free_name = gen_free_name(tree, env)
-    assert free_name == '__auto_name_0'
+    assert free_name == '_auto_name_0'
 
     free_name = gen_free_name(tree, env, prefix='P')
     assert free_name == 'P2'
@@ -51,7 +51,7 @@ P1 = P0()
     env = SymbolTable({}, {})
 
     free_prefix = gen_free_prefix(tree, env)
-    assert free_prefix == '__auto_prefix_0'
+    assert free_prefix == '_auto_prefix_0'
 
     free_prefix = gen_free_prefix(tree, env, 'P')
     assert free_prefix == 'P2'


### PR DESCRIPTION
`__NAMES` have strange behavior in class contexts so change the default to only have a single `_`