### PR TITLE
Add option to copy symbol table f_locals

### DIFF
--- a/ast_tools/stack.py
+++ b/ast_tools/stack.py
@@ -45,7 +45,7 @@ class SymbolTable(tp.Mapping[str, tp.Any]):
 
 def get_symbol_table(
         decorators: tp.Optional[tp.Sequence[inspect.FrameInfo]] = None,
-        copy_frames: bool = False
+        copy_locals: bool = False
         ) -> SymbolTable:
     exec(_SKIP_FRAME_DEBUG_STMT)
     locals = ChainMap()
@@ -70,12 +70,10 @@ def get_symbol_table(
             else:
                 logging.debug(f'{frame.function} @ {frame.filename}:{frame.lineno} might be leaking names')
         f_locals = stack[i].frame.f_locals
-        f_globals = stack[i].frame.f_globals
-        if copy_frames:
+        if copy_locals:
             f_locals = copy.copy(f_locals)
-            f_globals = copy.copy(f_globals)
         locals = locals.new_child(f_locals)
-        globals = globals.new_child(f_globals)
+        globals = globals.new_child(stack[i].frame.f_globals)
     return SymbolTable(locals=locals, globals=dict(globals))
 
 def inspect_symbol_table(

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -70,7 +70,7 @@ def test_get_symbol_table_copy_frames():
     copy_sts = []
     for i in range(5):
         non_copy_sts.append(stack.get_symbol_table())
-        copy_sts.append(stack.get_symbol_table(copy_frames=True))
+        copy_sts.append(stack.get_symbol_table(copy_locals=True))
     for j in range(5):
         assert non_copy_sts[j].locals["i"] == 4
         assert copy_sts[j].locals["i"] == j

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -64,3 +64,13 @@ def test_custom_env():
     st = stack.SymbolTable(locals={},globals={'MAGIC2':'bar'})
     test = stack.inspect_enclosing_env(test, st=st)
     test()
+
+def test_get_symbol_table_copy_frames():
+    non_copy_sts = []
+    copy_sts = []
+    for i in range(5):
+        non_copy_sts.append(stack.get_symbol_table())
+        copy_sts.append(stack.get_symbol_table(copy_frames=True))
+    for j in range(5):
+        assert non_copy_sts[j].locals["i"] == 4
+        assert copy_sts[j].locals["i"] == j


### PR DESCRIPTION
Addresses an issue when a symbol table is retrieved inside a loop and the loop variable is modified for each instance of the symbol table by adding a flag to copy the contents of f_locals during construction.