### PR TITLE
Add support for attribute passes

### DIFF
--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -34,9 +34,9 @@ class _DecoratorStripper(metaclass=ABCMeta):
     def set_decorators(tree, decorators): pass
 
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def get_name(node): pass
+    def lookup(cls, node, env): pass
 
 
     @classmethod

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -77,7 +77,7 @@ def foo():
 def test_debug(capsys):
     l0 = inspect.currentframe().f_lineno + 1
     @end_rewrite(file_name='test_debug.py')
-    @debug(dump_source_filename=True, dump_source_lines=True)
+    @ast_tools.passes.debug(dump_source_filename=True, dump_source_lines=True)
     @begin_rewrite(debug=True)
     def foo():
         print("bar")
@@ -88,7 +88,7 @@ END SOURCE_FILENAME
 
 BEGIN SOURCE_LINES
 {l0+0}:    @end_rewrite(file_name='test_debug.py')
-{l0+1}:    @debug(dump_source_filename=True, dump_source_lines=True)
+{l0+1}:    @ast_tools.passes.debug(dump_source_filename=True, dump_source_lines=True)
 {l0+2}:    @begin_rewrite(debug=True)
 {l0+3}:    def foo():
 {l0+4}:        print("bar")

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -1,9 +1,9 @@
 import os
-import functools
 import inspect
 
 import pytest
 
+import ast_tools
 from ast_tools.passes import begin_rewrite, end_rewrite, debug
 from ast_tools.passes import apply_ast_passes, apply_cst_passes
 from ast_tools.stack import SymbolTable
@@ -125,3 +125,25 @@ def test_custom_env():
         return x
 
     assert f() == 1
+
+
+@pytest.mark.parametrize('deco', [apply_ast_passes, apply_cst_passes])
+def test_apply_attribute(deco, capsys):
+    l0 = inspect.currentframe().f_lineno + 1
+    @deco([ast_tools.passes.debug(dump_source_filename=True,
+                                  dump_source_lines=True)], debug=True)
+    def foo():
+        print("bar")
+    assert capsys.readouterr().out == f"""\
+BEGIN SOURCE_FILENAME
+{os.path.abspath(__file__)}
+END SOURCE_FILENAME
+
+BEGIN SOURCE_LINES
+{l0+0}:    @deco([ast_tools.passes.debug(dump_source_filename=True,
+{l0+1}:                                  dump_source_lines=True)], debug=True)
+{l0+2}:    def foo():
+{l0+3}:        print("bar")
+END SOURCE_LINES
+
+"""

--- a/tests/test_passes.py
+++ b/tests/test_passes.py
@@ -125,25 +125,3 @@ def test_custom_env():
         return x
 
     assert f() == 1
-
-
-@pytest.mark.parametrize('deco', [apply_ast_passes, apply_cst_passes])
-def test_apply_attribute(deco, capsys):
-    l0 = inspect.currentframe().f_lineno + 1
-    @deco([ast_tools.passes.debug(dump_source_filename=True,
-                                  dump_source_lines=True)], debug=True)
-    def foo():
-        print("bar")
-    assert capsys.readouterr().out == f"""\
-BEGIN SOURCE_FILENAME
-{os.path.abspath(__file__)}
-END SOURCE_FILENAME
-
-BEGIN SOURCE_LINES
-{l0+0}:    @deco([ast_tools.passes.debug(dump_source_filename=True,
-{l0+1}:                                  dump_source_lines=True)], debug=True)
-{l0+2}:    def foo():
-{l0+3}:        print("bar")
-END SOURCE_LINES
-
-"""


### PR DESCRIPTION
Enables support for `m.combinational2` as a pass.  It augments the get_name logic to support basic attributes by recursing through the tree.  