### PR TITLE
Use ordered targets for ssa so we get deterministic output

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -471,7 +471,9 @@ class ssa(Pass):
         NR = _never_returns(tree.body)
 
         # Find all attributes that are written
-        targets = collect_targets(tree, ast.Attribute)
+        # Sort so we get determistic codegen
+        targets = sorted(collect_targets(tree, ast.Attribute),
+                         key=lambda x: ast.dump(x))
         replacer = AttrReplacer({})
         init_reads = set()
         attr_names = {}

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -477,14 +477,12 @@ class ssa(Pass):
         id_to_attr = {}
         attr_to_name = {}
 
-        seen = set()
         for t in targets:
             i_t = immutable(t)
             if not isinstance(t.value, ast.Name):
                 raise NotImplementedError(f'Only supports writing attributes '
                                           f'of Name not {type(t.value)}')
-            elif i_t not in seen:
-                seen.add(i_t)
+            elif i_t not in attr_to_name:
                 name = ast.Name(
                         id=gen_free_name(tree, env, '_'.join((t.value.id, t.attr))),
                         ctx=ast.Store())

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -471,9 +471,7 @@ class ssa(Pass):
         NR = _never_returns(tree.body)
 
         # Find all attributes that are written
-        # Sort so we get determistic codegen
-        targets = sorted(collect_targets(tree, ast.Attribute),
-                         key=lambda x: ast.dump(x))
+        targets = collect_targets(tree, ast.Attribute)
         replacer = AttrReplacer({})
         init_reads = set()
         attr_names = {}

--- a/ast_tools/visitors/collect_targets.py
+++ b/ast_tools/visitors/collect_targets.py
@@ -14,10 +14,10 @@ class TargetCollector(ast.NodeVisitor):
         if target_filter is None:
             target_filter = ast.AST
         self.target_filter = _filt(target_filter)
-        self.targets = set()
+        self.targets = []
 
     def visit_Assign(self, node: ast.Assign):
-        self.targets.update(filter(self.target_filter, node.targets))
+        self.targets.extend(filter(self.target_filter, node.targets))
 
 
 def collect_targets(tree, target_filter=None):


### PR DESCRIPTION
Not sure what the best way to deal with this is.  Basically, if we don't use a deterministic ordering for the targets logic, then we'll occasionally see different outputs when generating code in magma (just ordering of instances and wiring), which causes problems for our regression test.

The simplest change I found was to sort the targets by their dumped ast representation, but then I realized that the targets should be unique since we're never revisiting a node, so we can just use a list rather than a set since we shouldn't find any duplicates anyways.  This should have better performance than sorting the targets after the fact.

I'm open to alternatives, but basically I'm looking for a deterministic way to generate a targets list so the SSA code output is the same every time.