### PR TITLE
ssa: support magma sequential self.attr.prev()

### DIFF
--- a/ast_tools/visitors/__init__.py
+++ b/ast_tools/visitors/__init__.py
@@ -1,3 +1,4 @@
 from .used_names import *
+from .collect_calls import *
 from .collect_names import *
 from .collect_targets import *

--- a/ast_tools/visitors/collect_calls.py
+++ b/ast_tools/visitors/collect_calls.py
@@ -1,0 +1,19 @@
+"""
+Defines a visitor that collects all calls contained in an AST
+"""
+import ast
+
+class CallCollector(ast.NodeVisitor):
+    def __init__(self):
+        self.calls = []
+
+    def visit_Call(self, node: ast.Call):
+        self.calls.append(node)
+
+
+def collect_calls(tree):
+    visitor = CallCollector()
+    visitor.visit(tree)
+    return visitor.calls
+
+


### PR DESCRIPTION
porting magma sequential `self.attr.prev()` to ssa. it unblocks sequential2 to use `prev()`
https://github.com/phanrahan/magma/blob/b8dc5c0b40f1e69051d4f6a10b076df65cba6a9c/magma/syntax/sequential.py#L62-L67

source

    def __call__(self, val):
        self.cnt = self.cnt + val
        return self.cnt.prev()

ssa

    def __call__(self, val):
        self_cnt0 = self.cnt
        self_cnt1 = self_cnt0 + val
        __return_value0 = self.cnt
        self.cnt = self_cnt1
        return __return_value0