### PR TITLE
Pass metadata to exec

### DIFF
--- a/ast_tools/passes/util.py
+++ b/ast_tools/passes/util.py
@@ -205,14 +205,15 @@ class apply_passes(metaclass=ABCMeta):
 
         etree = self.strip_decorators(tree, env, type(self), None)
         stree = self.strip_decorators(tree, env, type(self), type(self))
-        return self.exec(etree, stree, env)
+        return self.exec(etree, stree, env, metadata)
 
 
 class apply_ast_passes(apply_passes):
     parse = staticmethod(get_ast)
     strip_decorators = staticmethod(_ASTStripper.strip)
 
-    def exec(self, etree: ast.AST, stree: ast.AST, env: SymbolTable):
+    def exec(self, etree: ast.AST, stree: ast.AST, env: SymbolTable,
+             metadata: tp.MutableMapping):
         etree = ast.fix_missing_locations(etree)
         stree = ast.fix_missing_locations(stree)
         return exec_def_in_file(etree, env, self.path, self.file_name, stree)
@@ -225,7 +226,7 @@ class apply_cst_passes(apply_passes):
     def exec(self,
             etree: tp.Union[cst.ClassDef, cst.FunctionDef],
             stree: tp.Union[cst.ClassDef, cst.FunctionDef],
-            env: SymbolTable):
+            env: SymbolTable, metadata: tp.MutableMapping):
         emod = cst.Module(body=(etree,))
         smod = cst.Module(body=(stree,))
         st = exec_str_in_file(emod.code, env, self.path, self.file_name, smod.code)


### PR DESCRIPTION
Working on a magma pass where having exec passed to metadata is useful (magma overrides exec and inside the logic I'd like to have some information that is inserted from a pass that is run).

Alternatively I could give the pass as reference to a object in the apply_ast_passes subclass, so there is a reasonable alternative that doesn't require this interface change, but maybe this would be more generally useful?