### PR TITLE
Fix for Python3.8 support

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -1,4 +1,5 @@
 import ast
+import sys
 from collections import ChainMap, Counter
 from copy import deepcopy
 import typing as tp
@@ -495,13 +496,13 @@ class ssa(Pass):
                 replacer.add_replacement(_flip_ctx(t), _flip_ctx(name))
 
                 # read the init value
-                init_reads.append(
-                    immutable(ast.Assign(
-                        targets=[deepcopy(name)],
-                        value=_flip_ctx(t),
-                        type_comment=None,
-                    ))
-                )
+                if sys.version_info < (3, 8):
+                    assign = ast.Assign(targets=[deepcopy(name)], value=_flip_ctx(t))
+                else:
+                    assign = ast.Assign(
+                            targets=[deepcopy(name)], value=_flip_ctx(t),
+                            type_comment=None)
+                init_reads.append(immutable(assign))
             else:
                 name = attr_to_name[i_t]
                 replacer.add_replacement(t, name)


### PR DESCRIPTION
The Python 3.8 support code `ast.Assign` with `type_comment=None` breaks pip package,
which was packaged with Python 3.7. This PR solves the issue but keeps Python 3.8 support.

Example https://travis-ci.org/github/phanrahan/magma/builds/714625815
> E       TypeError: __init__() got an unexpected keyword argument 'type_comment'
