### PR TITLE
Fix builtins logic for old style

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -1,3 +1,4 @@
+import sys
 from collections import ChainMap, Counter
 import builtins
 import functools as ft
@@ -339,7 +340,7 @@ class SSATransformer(InsertStatementsVisitor):
             strict: bool = True,
             ):
         super().__init__(cst.codemod.CodemodContext())
-        self.env = ChainMap(env, env.get('__builtins__', builtins).__dict__)
+        self.env = ChainMap(env, env.get('__builtins__', builtins.__dict__))
         self.ctxs = ctxs
         self.scope = None
         self.name_idx = Counter()


### PR DESCRIPTION
I'm not sure what to do here, reading this doc: https://docs.python.org/3.8/library/builtins.html?highlight=builtins#module-builtins it seems that it could either be the module or the value of __dict__.

I needed this fix for python 3.8, but it could be the case that other versions need something different? Is there a portable way to do this? Can we just always use the builtins module?