### PR TITLE
Always use builtins module

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -339,7 +339,7 @@ class SSATransformer(InsertStatementsVisitor):
             strict: bool = True,
             ):
         super().__init__(cst.codemod.CodemodContext())
-        self.env = ChainMap(env, env.get('__builtins__', builtins).__dict__)
+        self.env = ChainMap(env, builtins.__dict__)
         self.ctxs = ctxs
         self.scope = None
         self.name_idx = Counter()


### PR DESCRIPTION
It's not clear from the docs (https://docs.python.org/3.8/library/builtins.html?highlight=builtins#module-builtins) whether __builtins__ is the module or the __dict__ of the module.  Always using the builtins module seems to work, but perhaps is not backwards compatible with older python versions? Since this works in 3.8, I think it should be okay and we don't need to support older than that