### PR TITLE
Ignore keyword arguments in SSA logic

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -486,6 +486,12 @@ class SSATransformer(InsertStatementsVisitor):
         final_node = updated_node.with_changes(value=new_value)
         return super().leave_Attribute(original_node, final_node)
 
+    def leave_Arg(self, original_node: cst.Arg, updated_node: cst.Arg):
+        # Assumes that visiting the keyword doesn't affect the logic (since it
+        # should always be a read?). If so we can just discard any changes by
+        # reusing the original keyword node
+        return updated_node.with_changes(keyword=original_node.keyword)
+
     def leave_Name(self,
             original_node: cst.Name,
             updated_node: cst.Name) -> cst.Name:


### PR DESCRIPTION
Assumes that when we visit an Arg node (as part of a Call), this should
always be in the "reading" context (so it will just replace the
reference with the latest SSA value, but not cause any changes to the
state of the SSA mappings).  Then, we can just discard the changes and
reuse the original keyword (since these are not variable names that
should be affected by SSA).