### PR TITLE
Prototype Symbol Table for SSA

### DIFF
--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -264,8 +264,7 @@ class SingleReturn(InsertStatementsVisitor):
             self.added_names.add(attr_name.value)
             self.symbol_table_skip_targets.add(attr_name)
             state.append((cond, attr_name))
-            node = make_assign(attr_name, cst.Name(name))
-            assignments.append(node)
+            assignments.append(make_assign(attr_name, cst.Name(name)))
 
         r_name = cst.Name(value=self.return_format.format(len(self.returns)))
         self.added_names.add(r_name.value)

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -505,8 +505,6 @@ class SSATransformer(InsertStatementsVisitor):
             original_node: cst.Assign,
             updated_node: cst.Assign) -> cst.Assign:
         if (len(updated_node.targets) == 1 and
-                match.matches(updated_node.targets[0],
-                              match.AssignTarget()) and
                 updated_node.targets[0].target in self.symbol_table_skip_targets):
             self.symbol_table_skip = True
             self.symbol_table_offset += 1

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -354,7 +354,6 @@ class SSATransformer(InsertStatementsVisitor):
             symbol_table_skip_targets: tp.AbstractSet[str],
             returning_blocks: tp.AbstractSet[cst.BaseSuite],
             metadata: tp.MutableMapping,
-            symbol_table_offset: int,
             strict: bool = True,
             ):
         super().__init__(cst.codemod.CodemodContext())
@@ -372,7 +371,7 @@ class SSATransformer(InsertStatementsVisitor):
         # Track which assign targets to skip (compiler introduced lines)
         self.symbol_table_skip_targets = symbol_table_skip_targets
         # Used to track the line offset for skipped lines
-        self.symbol_table_offset = symbol_table_offset
+        self.symbol_table_offset = 0
         # Used to track when to skip adding names to symbol table
         self.symbol_table_skip = False
 
@@ -664,7 +663,6 @@ class ssa(Pass):
                 single_return.symbol_table_skip_targets,
                 single_return.returning_blocks,
                 metadata,
-                len(init_reads),
                 strict=self.strict)
         tree = wrapper.visit(ssa_transformer).body[0]
 

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -368,17 +368,20 @@ class SSATransformer(InsertStatementsVisitor):
         self.name_table = ChainMap({k: k for k in self.env})
         self.name_formats = {}
         self.final_names = final_names
+
+        # Track which assign targets to skip (compiler introduced lines)
         self.symbol_table_skip_targets = symbol_table_skip_targets
+        # Used to track the line offset for skipped lines
+        self.symbol_table_offset = symbol_table_offset
+        # Used to track when to skip adding names to symbol table
+        self.symbol_table_skip = False
+
         self.strict = strict
         self.returning_blocks = returning_blocks
         self._in_keyword = False
         if "ssa_symbol_table" in metadata:
             raise Exception("SSA symbol table already in metadata")
         metadata["ssa_symbol_table"] = self.ssa_symbol_table = defaultdict(dict)
-        # Skip lines before offset because it's part of init_reads, so not in
-        # user code
-        self.symbol_table_offset = symbol_table_offset
-        self.symbol_table_skip = False
 
 
     def _make_name(self, name):

--- a/ast_tools/passes/ssa.py
+++ b/ast_tools/passes/ssa.py
@@ -587,6 +587,9 @@ class ssa(Pass):
         init_reads = []
         names_to_attr = {}
         seen = set()
+
+        # Store the names introduced for attributes so we can map them to the
+        # original attribute in the symbol table (post ssa)
         name_to_attr_map = {}
 
         # Statements that assign to these targets are skipped by the symbol

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -372,26 +372,26 @@ def test_attr():
                     env: SymbolTable,
                     metadata: tp.MutableMapping) -> PASS_ARGS_T:
             assert "ssa_symbol_table" in metadata
-#       def f1(x, y):
-# 1.        z = bar(1, 0)
-# 2.        if x:
-# 3.            a = z
-# 4.        else:
-# 5.            a = y
-# 6.        if x & y:
-# 7.            return a
-# 8.        a.x = z
-# 9.        return a
+#  1.    def f1(x, y):
+#  2.        z = bar(1, 0)
+#  3.        if x:
+#  4.            a = z
+#  5.        else:
+#  6.            a = y
+#  7.        if x & y:
+#  8.            return a
+#  9.        a.x = z
+# 10.        return a
             assert str(metadata["ssa_symbol_table"]) == """\
 defaultdict(<class 'dict'>, {\
-1: {'bar': 'bar', 'z': 'z_0'}, \
-2: {'x': 'x'}, \
-3: {'z': 'z_0', 'a': 'a_0'}, \
-5: {'y': 'y', 'a': 'a_1'}, \
-6: {'x': 'x', 'y': 'y'}, \
-7: {'a': 'a_2'}, \
-8: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, \
-9: {'a': 'a_2'}})\
+2: {'bar': 'bar', 'z': 'z_0'}, \
+3: {'x': 'x'}, \
+4: {'z': 'z_0', 'a': 'a_0'}, \
+6: {'y': 'y', 'a': 'a_1'}, \
+7: {'x': 'x', 'y': 'y'}, \
+8: {'a': 'a_2'}, \
+9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, \
+10: {'a': 'a_2'}})\
 """
             return tree, env, metadata
 

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -373,16 +373,16 @@ def test_attr():
                     metadata: tp.MutableMapping) -> PASS_ARGS_T:
             assert "ssa_symbol_table" in metadata
             assert str(metadata["ssa_symbol_table"]) == (
-                "defaultdict(<class 'dict'>, {"           #  1.    def f1(x, y):
-                "2: {'bar': 'bar', 'z': 'z_0'}, "         #  2.        z = bar(1, 0)
-                "3: {'x': 'x'}, "                         #  3.        if x:
-                "4: {'z': 'z_0', 'a': 'a_0'}, "           #  4.            a = z
-                                                          #  5.        else:
-                "6: {'y': 'y', 'a': 'a_1'}, "             #  6.            a = y
-                "7: {'x': 'x', 'y': 'y'}, "               #  7.        if x & y:
-                "8: {'a': 'a_2'}, "                       #  8.            return a
-                "9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, " #  9.        a.x = z
-                "10: {'a': 'a_2'}})"                      # 10.        return a
+                "defaultdict(<class 'dict'>, {"  # noqa      1. def f1(x, y):
+                "2: {'bar': 'bar', 'z': 'z_0'}, "  # noqa    2.     z = bar(1, 0)
+                "3: {'x': 'x'}, "  # noqa                    3.     if x:
+                "4: {'z': 'z_0', 'a': 'a_0'}, "   # noqa     4.         a = z
+                                                          #  5.     else:
+                "6: {'y': 'y', 'a': 'a_1'}, "  # noqa        6.         a = y
+                "7: {'x': 'x', 'y': 'y'}, "   # noqa         7.     if x & y:
+                "8: {'a': 'a_2'}, "   # noqa                 8.         return a
+                "9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, "  # 9.     a.x = z
+                "10: {'a': 'a_2'}})"   # noqa               10.     return a
             )
             return tree, env, metadata
 

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -372,27 +372,18 @@ def test_attr():
                     env: SymbolTable,
                     metadata: tp.MutableMapping) -> PASS_ARGS_T:
             assert "ssa_symbol_table" in metadata
-#  1.    def f1(x, y):
-#  2.        z = bar(1, 0)
-#  3.        if x:
-#  4.            a = z
-#  5.        else:
-#  6.            a = y
-#  7.        if x & y:
-#  8.            return a
-#  9.        a.x = z
-# 10.        return a
-            assert str(metadata["ssa_symbol_table"]) == """\
-defaultdict(<class 'dict'>, {\
-2: {'bar': 'bar', 'z': 'z_0'}, \
-3: {'x': 'x'}, \
-4: {'z': 'z_0', 'a': 'a_0'}, \
-6: {'y': 'y', 'a': 'a_1'}, \
-7: {'x': 'x', 'y': 'y'}, \
-8: {'a': 'a_2'}, \
-9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, \
-10: {'a': 'a_2'}})\
-"""
+            assert str(metadata["ssa_symbol_table"]) == (
+                "defaultdict(<class 'dict'>, {"           #  1.    def f1(x, y):
+                "2: {'bar': 'bar', 'z': 'z_0'}, "         #  2.        z = bar(1, 0)
+                "3: {'x': 'x'}, "                         #  3.        if x:
+                "4: {'z': 'z_0', 'a': 'a_0'}, "           #  4.            a = z
+                                                          #  5.        else:
+                "6: {'y': 'y', 'a': 'a_1'}, "             #  6.            a = y
+                "7: {'x': 'x', 'y': 'y'}, "               #  7.        if x & y:
+                "8: {'a': 'a_2'}, "                       #  8.            return a
+                "9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, " #  9.        a.x = z
+                "10: {'a': 'a_2'}})"                      # 10.        return a
+            )
             return tree, env, metadata
 
     f2 = apply_passes([ssa(False), CheckSymbolTable()])(f1)

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -372,18 +372,17 @@ def test_attr():
                     env: SymbolTable,
                     metadata: tp.MutableMapping) -> PASS_ARGS_T:
             assert "ssa_symbol_table" in metadata
-            assert str(metadata["ssa_symbol_table"]) == (
-                "defaultdict(<class 'dict'>, {"           #  1. def f1(x, y):
-                "2: {'bar': 'bar', 'z': 'z_0'}, "         #  2.     z = bar(1, 0)
-                "3: {'x': 'x'}, "                         #  3.     if x:
-                "4: {'z': 'z_0', 'a': 'a_0'}, "           #  4.         a = z
-                                                          #  5.     else:
-                "6: {'y': 'y', 'a': 'a_1'}, "             #  6.         a = y
-                "7: {'x': 'x', 'y': 'y'}, "               #  7.     if x & y:
-                "8: {'a': 'a_2'}, "                       #  8.         return a
-                "9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, " #  9.     a.x = z
-                "10: {'a': 'a_2'}})"                      # 10.     return a
-            )
+            assert metadata["ssa_symbol_table"] == {
+                2: {'bar': 'bar', 'z': 'z_0'},          #  2.     z = bar(1, 0)
+                3: {'x': 'x'},                          #  3.     if x:
+                4: {'z': 'z_0', 'a': 'a_0'},            #  4.         a = z
+                                                        #  5.     else:
+                6: {'y': 'y', 'a': 'a_1'},              #  6.         a = y
+                7: {'x': 'x', 'y': 'y'},                #  7.     if x & y:
+                8: {'a': 'a_2'},                        #  8.         return a
+                9: {'z': 'z_0', 'a.x': '_attr_a_x_1'},  #  9.     a.x = z
+                10: {'a': 'a_2'}                        # 10.     return a
+            }
             return tree, env, metadata
 
     f2 = apply_passes([ssa(False), CheckSymbolTable()])(f1)

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -372,27 +372,26 @@ def test_attr():
                     env: SymbolTable,
                     metadata: tp.MutableMapping) -> PASS_ARGS_T:
             assert "ssa_symbol_table" in metadata
-#  1.    def f1(x, y):
-#  2.        z = bar(1, 0)
-#  3.        if x:
-#  4.            a = z
-#  5.        else:
-#  6.            a = y
-#  7.        if x & y:
-#  8.            return a
-#  9.        a.x = z
-# 10.        return a
+#       def f1(x, y):
+# 1.        z = bar(1, 0)
+# 2.        if x:
+# 3.            a = z
+# 4.        else:
+# 5.            a = y
+# 6.        if x & y:
+# 7.            return a
+# 8.        a.x = z
+# 9.        return a
             assert str(metadata["ssa_symbol_table"]) == """\
 defaultdict(<class 'dict'>, {\
-15: {'a': 'a'}, \
-2: {'bar': 'bar', 'z': 'z_0'}, \
-3: {'x': 'x'}, \
-4: {'z': 'z_0', 'a': 'a_0'}, \
-6: {'y': 'y', 'a': 'a_1'}, \
-7: {'x': 'x', 'y': 'y'}, \
-8: {'a': 'a_2'}, \
-9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, \
-10: {'a': 'a_2'}})\
+1: {'bar': 'bar', 'z': 'z_0'}, \
+2: {'x': 'x'}, \
+3: {'z': 'z_0', 'a': 'a_0'}, \
+5: {'y': 'y', 'a': 'a_1'}, \
+6: {'x': 'x', 'y': 'y'}, \
+7: {'a': 'a_2'}, \
+8: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, \
+9: {'a': 'a_2'}})\
 """
             return tree, env, metadata
 

--- a/tests/test_ssa.py
+++ b/tests/test_ssa.py
@@ -373,16 +373,16 @@ def test_attr():
                     metadata: tp.MutableMapping) -> PASS_ARGS_T:
             assert "ssa_symbol_table" in metadata
             assert str(metadata["ssa_symbol_table"]) == (
-                "defaultdict(<class 'dict'>, {"  # noqa      1. def f1(x, y):
-                "2: {'bar': 'bar', 'z': 'z_0'}, "  # noqa    2.     z = bar(1, 0)
-                "3: {'x': 'x'}, "  # noqa                    3.     if x:
-                "4: {'z': 'z_0', 'a': 'a_0'}, "   # noqa     4.         a = z
+                "defaultdict(<class 'dict'>, {"           #  1. def f1(x, y):
+                "2: {'bar': 'bar', 'z': 'z_0'}, "         #  2.     z = bar(1, 0)
+                "3: {'x': 'x'}, "                         #  3.     if x:
+                "4: {'z': 'z_0', 'a': 'a_0'}, "           #  4.         a = z
                                                           #  5.     else:
-                "6: {'y': 'y', 'a': 'a_1'}, "  # noqa        6.         a = y
-                "7: {'x': 'x', 'y': 'y'}, "   # noqa         7.     if x & y:
-                "8: {'a': 'a_2'}, "   # noqa                 8.         return a
-                "9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, "  # 9.     a.x = z
-                "10: {'a': 'a_2'}})"   # noqa               10.     return a
+                "6: {'y': 'y', 'a': 'a_1'}, "             #  6.         a = y
+                "7: {'x': 'x', 'y': 'y'}, "               #  7.     if x & y:
+                "8: {'a': 'a_2'}, "                       #  8.         return a
+                "9: {'z': 'z_0', 'a.x': '_attr_a_x_1'}, " #  9.     a.x = z
+                "10: {'a': 'a_2'}})"                      # 10.     return a
             )
             return tree, env, metadata
 


### PR DESCRIPTION
The goal here is to add logic to the SSA pass to track the name changes introduced.

The output format desired is:
```
for each line:
    for each variable:
        add map from original variable -> ssa variable
```
Since the variables are uniquely named in SSA, we don't need to annotate which line it corresponds to in the SSA program, just the variable name (we could use this to discover the relevant line where it's defined, or if needed we could include the line information during construction easily)

Most of the complexity arises in accounting for the extra lines added by the compiler (init reads, name tests for conditions, final assigns).  Also we need to handle mapping from attribute references to the attribute ssa variable.

This mostly was an attempt at reaching an okay looking table for the simple test example, it may be the case that we need to generalize the logic for more complex cases.  For tracking the introduced lines, I just use a set of cst nodes, a metadataprovider might be a better pattern (add metadata marking these nodes to be handled by symbol table logic), but this seemed simpler and gets the job done.  It's not clear if you can make both a transformer and metadataprovider in one entity? That's what we need since the return transformer needs to add metadata to the nodes it's adding.

We may want to rework the line skipping logic if we think about mapping errors from the SSA code to the original code.  Basically for each line the SSA program, it corresponds to a line in the original code.  Multiple lines may correspond to the same line (e.g. a return statement expands into multiple lines).  Then, if we find an exception raised in the SSA code, we can trace it back to the original source line that generated the SSA line with the error.  With this information, the line skipping logic in the SSA pass might be easier to capture.