### PR TITLE
Updating link to greentreesnakes.readthedocs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ pip install ast_tools
 ```
 
 # Useful References
-* [Green Tree Snakes - the missing Python AST docs](greentreesnakes.readthedocs.io/)
+* [Green Tree Snakes - the missing Python AST docs](https://greentreesnakes.readthedocs.io/)
 
 
 # Passes


### PR DESCRIPTION
The readme link in Github and pypi doesn't work. I've updated it so that it will work.